### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Then you'll need to have [terraform](https://learn.hashicorp.com/tutorials/terra
 ```sh
 brew tap hashicorp/tap
 brew install hashicorp/tap/terraform # OR brew install opentofu
-brew install packer
+brew install hashicorp/tap/packer
 brew install kubectl
 brew install hcloud
 ```


### PR DESCRIPTION
The Brew formular for Packer mentioned in the Readme is [disabled](https://formulae.brew.sh/formula/packer). According to Hashicorp's documentation, the new form is [**hashicorp/tap/packer**](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli).